### PR TITLE
Permitir la eliminación de duplicados antes de imprimir la lista de items

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,9 +10,12 @@ DEFAULT_FILENAME = "words.txt"
 DEFAULT_DUPLICATES = False
 
 
-def sort_list(items, ascending=True):
+def sort_list(items, ascending=True, remove_duplicates=False):
     if not isinstance(items, list):
         raise RuntimeError(f"No puede ordenar {type(items)}")
+
+    if remove_duplicates:
+        items = remove_duplicates_from_list(items)
 
     return sorted(items, reverse=(not ascending))
 
@@ -43,7 +46,4 @@ if __name__ == "__main__":
         print(f"El fichero {filename} no existe")
         word_list = ["ravenclaw", "gryffindor", "slytherin", "hufflepuff"]
 
-    if remove_duplicates:
-        word_list = remove_duplicates_from_list(word_list)
-
-    print(sort_list(word_list))
+    print(sort_list(word_list), remove_duplicates=remove_duplicates)


### PR DESCRIPTION
Cambios propuestos para la feature:

>   ▸	Aceptar un nuevo parámetro de línea de comandos que indique si es necesario eliminar palabras duplicadas de la lista antes de imprimirlas (en este caso habrá que modificar la función sort_list).

En el caso de que se utilizase un fichero .txt o un array como el siguiente: 
`palabras = ["manzana", "pera", "manzana", "uva", "plátano", "pera"]`

El resultado ó salida de ejecutar este script en Python sería:
```
Se leerán las palabras del fichero mispalabras.txt
['manzana', 'pera', 'plátano', 'uva']

** Process exited - Return Code: 0 **
```